### PR TITLE
ardupilot_ros: fix cartographer subscribing to /tf_static instead of /ap/tf_static

### DIFF
--- a/launch/cartographer.launch.py
+++ b/launch/cartographer.launch.py
@@ -28,6 +28,7 @@ def generate_launch_description():
         remappings=[
             ("/scan", "/laser/scan"),
             ("/tf", "/ap/tf"),
+            ("/tf_static", "/ap/tf_static"),
         ],
         output="screen",
     )


### PR DESCRIPTION
Cartographer was subscribing to `/tf_static` instead of `/ap/tf_static`, which sometimes caused it to publish the gazebo transforms into `/ap/tf`. 
This didn't cause any known issues, but it is worth fixing to separate the trees completely.

Closely related to the remap commit on #8 