### PR TITLE
Remove remaps from cartographer launch files

### DIFF
--- a/launch/cartographer.launch.py
+++ b/launch/cartographer.launch.py
@@ -25,11 +25,6 @@ def generate_launch_description():
             "-configuration_basename",
             "cartographer.lua",
         ],
-        remappings=[
-            ("/scan", "/laser/scan"),
-            ("/tf", "/ap/tf"),
-            ("/tf_static", "/ap/tf_static"),
-        ],
         output="screen",
     )
 
@@ -57,10 +52,6 @@ def generate_launch_description():
             ),
         ],
         condition=IfCondition(LaunchConfiguration("rviz")),
-        remappings=[
-            ("/tf", "/ap/tf"),
-            ("/tf_static", "/ap/tf_static"),
-        ],
     )
 
     return LaunchDescription(


### PR DESCRIPTION
This PR is part of a group of PRs with focus on eliminating the excessive remaps in `ardupilot_gz`, `AP_DDS` and `ardupilot_ros`

https://github.com/ArduPilot/ardupilot_gz/pull/27
https://github.com/ArduPilot/ardupilot/pull/24819