### PR TITLE
Add missing xmllint and workflow not triggering correctly

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,7 +1,11 @@
 ---
 name: pre-commit
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [humble]
+
 
 concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
@@ -12,23 +16,12 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
-    # steps:
-    #   # git checkout the PR
-    #   - uses: actions/checkout@v4
-    #     with:
-    #       submodules: 'recursive'
-    #   - name: Install pre-commit tool
-    #     run: |
-    #       apk update
-    #       apk add python3 py3-pip --no-cache
-    #       python3 -m pip install pre-commit
-    #   - name: Install pre-commit in repo
-    #     run: |
-    #       pre-commit install
-    #   - name: Run pre-commit
-    #     run: |
-    #       pre-commit run --all-files --verbose --show-diff-on-failure
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v3
+      - name: Install pre-commit dependencies
+        shell: 'bash'
+        run: |
+          sudo apt update
+          sudo apt install --no-install-recommends libxml2-utils
       - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
CI was failing because it was merged without the previous workflow succeeding. This fixes missing xmllint and the workflow now passes.