### PR TITLE
Fix pynput wrong key

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,7 @@
   <description>The ardupilot ROS 2 use cases package</description>
   <maintainer email="pedrofuoco6@gmail.com">Pedro Fuoco</maintainer>
   <license>GPLv3+</license>
-  <exec_depend>pynput</exec_depend>
+  <exec_depend>pynput-pip</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>ardupilot_gz_description</exec_depend>
   <exec_depend>ardupilot_gz_gazebo</exec_depend>


### PR DESCRIPTION
https://index.ros.org/d/pynput-pip/

Wrong key was used originally.

To test- use README :
```
rosdep install --from-paths src --ignore-src -r
```