### PR TITLE
Fix missing nav2 bringup dependency (and sort)

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,6 @@
   <description>The ardupilot ROS 2 use cases package</description>
   <maintainer email="pedrofuoco6@gmail.com">Pedro Fuoco</maintainer>
   <license>GPLv3+</license>
-  <exec_depend>pynput-pip</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>ardupilot_gz_description</exec_depend>
   <exec_depend>ardupilot_gz_gazebo</exec_depend>
@@ -14,10 +13,12 @@
   <exec_depend>cartographer_ros</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
-  <exec_depend>ros_gz_sim</exec_depend>
-  <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>topic_tools</exec_depend>
+  <exec_depend>nav2_bringup</exec_depend>
   <exec_depend>navigation2</exec_depend>
+  <exec_depend>pynput-pip</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>ros_gz_sim</exec_depend>
+  <exec_depend>topic_tools</exec_depend>
   <exec_depend>twist_stamper</exec_depend>
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
# Purpose


I added a missing `nav2_bringup` dependency and sorted the rest.

# Logs

Before this change on a fresh system
```bash
ryan@B650-970:~/Dev/ardu_ws$ ros2 launch ardupilot_ros navigation.launch.py
[INFO] [launch]: All log files can be found below /home/ryan/.ros/log/2024-10-29-06-27-47-422526-B650-970-523242
[INFO] [launch]: Default logging verbosity is set to INFO
[ERROR] [launch]: Caught exception in launch (see debug for traceback): Caught multiple exceptions when trying to load file of format [py]:
 - PackageNotFoundError: "package 'nav2_bringup' not found, searching: ['/home/ryan/Dev/ardu_ws/install/ardupilot_gz_bringup', '/home/ryan/Dev/ardu_ws/install/sdformat_urdf', '/home/ryan/Dev/ardu_ws/install/ardupilot_ros', '/home/ryan/Dev/ardu_ws/install/ros_gz_sim', '/home/ryan/Dev/ardu_ws/install/ros_gz_bridge', '/home/ryan/Dev/ardu_ws/install/ros_gz_interfaces', '/home/ryan/Dev/ardu_ws/install/ardupilot_dds_tests', '/home/ryan/Dev/ardu_ws/install/ardupilot_sitl', '/home/ryan/Dev/ardu_ws/install/micro_ros_agent', '/home/ryan/Dev/ardu_ws/install/ardupilot_sitl_models', '/home/ryan/Dev/ardu_ws/install/ardupilot_msgs', '/home/ryan/Dev/ardu_ws/install/ardupilot_gz_gazebo', '/home/ryan/Dev/ardu_ws/install/ardupilot_gz_description', '/home/ryan/Dev/ardu_ws/install/ardupilot_gazebo', '/opt/ros/humble']"
 - InvalidFrontendLaunchFileError: The launch file may have a syntax error, or its format is unknown
(failed reverse-i-search)`rosdep': ros2 launch ardupilot_^Cs navigation.launch.py
```