### PR TITLE
Add Sysid to nav2

### DIFF
--- a/ardupilot_cartographer/README.md
+++ b/ardupilot_cartographer/README.md
@@ -80,13 +80,16 @@ source install/setup.sh
 ros2 launch ardupilot_cartographer cartographer.launch.py rviz:=false
 ```
 
-Launch nav2:
+Launch Nav2:
 
 ```bash
 cd ~/ros2_ws
 source install/setup.sh
-ros2 launch ardupilot_cartographer navigation.launch.py
+ros2 launch ardupilot_cartographer navigation.launch.py sysid:=0
 ```
+
+Note when using the ``DDS_USE_NS=1`` parameter in ArduPilot, the ``sysid:=n`` needs to be used in Nav2,
+where ``n`` is the sysid of the vehicle.
 
 Takeoff the Copter using `mavproxy` to an altitude of 2.5m:
 

--- a/ardupilot_cartographer/launch/navigation.launch.py
+++ b/ardupilot_cartographer/launch/navigation.launch.py
@@ -1,7 +1,12 @@
 import os
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, GroupAction
+from launch.actions import (
+    DeclareLaunchArgument,
+    IncludeLaunchDescription,
+    GroupAction,
+    OpaqueFunction,
+)
 from launch.substitutions import LaunchConfiguration
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.conditions import IfCondition
@@ -13,7 +18,15 @@ from pathlib import Path
 """Generate a launch description for the navigation example."""
 
 
-def generate_launch_description():
+def setup_navigation(context):
+    """Setup navigation with dynamic topic prefix based on sysid."""
+    sysid = int(context.launch_configurations["sysid"])
+
+    if sysid > 0:
+        topic_prefix = f"/ap/v{sysid}"
+    else:
+        topic_prefix = "/ap"
+
     # Navigation
     navigation = GroupAction(
         actions=[
@@ -51,22 +64,9 @@ def generate_launch_description():
         ],
         remappings=[
             ("cmd_vel_in", "cmd_vel"),
-            ("cmd_vel_out", "ap/cmd_vel"),
+            ("cmd_vel_out", f"{topic_prefix}/cmd_vel"),
         ],
     )
-
-    # Robot description.
-
-    # Ensure `SDF_PATH` is populated as `sdformat_urdf`` uses this rather
-    # than `GZ_SIM_RESOURCE_PATH` to locate resources.
-    if "GZ_SIM_RESOURCE_PATH" in os.environ:
-        gz_sim_resource_path = os.environ["GZ_SIM_RESOURCE_PATH"]
-
-        if "SDF_PATH" in os.environ:
-            sdf_path = os.environ["SDF_PATH"]
-            os.environ["SDF_PATH"] = sdf_path + ":" + gz_sim_resource_path
-        else:
-            os.environ["SDF_PATH"] = gz_sim_resource_path
 
     # RViz.
     rviz = Node(
@@ -87,13 +87,33 @@ def generate_launch_description():
         condition=IfCondition(LaunchConfiguration("rviz")),
     )
 
+    return [navigation, twist_stamper, rviz]
+
+
+def generate_launch_description():
+    # Ensure `SDF_PATH` is populated as `sdformat_urdf` uses this rather
+    # than `GZ_SIM_RESOURCE_PATH` to locate resources.
+    if "GZ_SIM_RESOURCE_PATH" in os.environ:
+        gz_sim_resource_path = os.environ["GZ_SIM_RESOURCE_PATH"]
+
+        if "SDF_PATH" in os.environ:
+            sdf_path = os.environ["SDF_PATH"]
+            os.environ["SDF_PATH"] = sdf_path + ":" + gz_sim_resource_path
+        else:
+            os.environ["SDF_PATH"] = gz_sim_resource_path
+
+    sysid_arg = DeclareLaunchArgument(
+        "sysid",
+        default_value="0",
+        description="System ID for the MAVLink vehicle. 0 means no sysid prefix.",
+    )
+
     return LaunchDescription(
         [
             DeclareLaunchArgument(
                 "rviz", default_value="true", description="Open RViz."
             ),
-            navigation,
-            twist_stamper,
-            rviz,
+            sysid_arg,
+            OpaqueFunction(function=setup_navigation),
         ]
     )

--- a/ardupilot_gui/ardupilot_gui/gui.py
+++ b/ardupilot_gui/ardupilot_gui/gui.py
@@ -599,7 +599,7 @@ class ArduPilotGUI(QMainWindow):
         return self.copter_plane_frame
 
     def _create_velocity_control(self):
-        """Create velocity information display (read-only) for /ap/cmd_vel only."""
+        """Create velocity information display (read-only) for /ap/v1/cmd_vel only."""
         vel_frame = QFrame()
         vel_frame.setFrameStyle(QFrame.StyledPanel)
         vel_frame.setMaximumHeight(160)
@@ -612,7 +612,7 @@ class ArduPilotGUI(QMainWindow):
         vel_layout.addWidget(vel_title)
 
         # Topic title
-        ap_title = QLabel("/ap/cmd_vel")
+        ap_title = QLabel(f"{self.node.topic_prefix}/cmd_vel")
         ap_title.setFont(QFont("Arial", 10, QFont.Bold))
         ap_title.setStyleSheet("QLabel { color: #1976D2; }")
         vel_layout.addWidget(ap_title)


### PR DESCRIPTION
Found during testing of https://github.com/ArduPilot/ardupilot_gz/pull/89.

The topic mapping for Nav2 needs to change from ``/ap/cmd_vel`` to ``/ap/vN/cmd_vel`` to account for the new topic format.

So I've now added an argument i the Nav2 launch file to specify the sysid (or 0 to use the old format). This is the same are what was used for ardupilot_gui.

Also fixed up the ``cmd_vel`` label in ardupilot_gui

EDIT:
Tested in SITL with wildthumper model