### PR TITLE
docs(readme): recommend Gazebo Harmonic rosdep sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ cd ~/ros2_ws/src
 git clone git@github.com:ardupilot/ardupilot_ros.git
 ```
 
+If using a non-default Gazebo version for your ROS distro (e.g. Gazebo Harmonic with ROS 2 Humble),
+add Gazebo's rosdep sources so `package.xml` dependencies such as `ros_gz_sim` resolve correctly.
+See the [Gazebo rosdep guide](https://gazebosim.org/docs/harmonic/ros_installation#using-a-specific-gazebo-version-with-ros-2)
+for details:
+```bash
+sudo wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/00-gazebo.list -O /etc/ros/rosdep/sources.list.d/00-gazebo.list
+rosdep update
+```
+
 Install dependencies using rosdep:
 ```bash
 cd ~/ros2_ws


### PR DESCRIPTION
Fixes #32

**What**

Adds a step to the README's `rosdep install` instructions telling users to
register Gazebo's rosdep source list (`00-gazebo.list`) before installing
`package.xml` dependencies, when running a non-default Gazebo/ROS pairing
(e.g. Gazebo Harmonic on ROS 2 Humble — the combination the repo's CI pipeline
uses).

**Why**

As noted in ArduPilot/ardupilot_wiki#6359 and this issue, `rosdep` on a
stock ROS distro doesn't know about non-default Gazebo packages (for ex.
`ros_gz_sim`). So, `rosdep install` fails to resolve them. The README's
existing `-r` flag silently swallows that failure, allowing continuation, instead of surfacing the missing deps error. Contributors then hit confusing build errors later down the line, as the issue demonstrates.

The fix mirrors what `.github/workflows/colcon.yml` already does in CI: https://github.com/ArduPilot/ardupilot_ros/blob/d667f81907324b25a3404c8e161c6d2d97723125/.github/workflows/colcon.yml#L43)

It also reflects what ArduPilot wiki's ROS2/Gazebo [install page](https://ardupilot.org/dev/docs/ros2-gazebo.html) now recommends: add
`https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/00-gazebo.list`
to `/etc/ros/rosdep/sources.list.d/`, then `rosdep update`, before running
`rosdep install`.

**Scope**

Documentation only (`README.md`), one new step, no code changes. Left the
existing `rosdep install --from-paths src --ignore-src -r --skip-keys
gazebo-ros-pkgs` command as-is. The issue asks to recommend the `rosdep`
source, not to change that command's flags, and `gazebo-ros-pkgs` is an
unrelated legacy key that still needs the skip.

Note, the link I added to the README leads to these "outdated docs", but this is version matched to CI and should remain.
<img width="924" height="148" alt="Screenshot 2026-07-26 at 1 59 16 PM" src="https://github.com/user-attachments/assets/239ccf1a-6b69-4882-894f-8eead555f379" />

Future change might re-consider the `-r` flag that swallows errors. If that is the desired state going forward, maybe a warning log or something would help?
